### PR TITLE
main: omit explicit request host and port if unspecified, thus allowi…

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -366,7 +366,13 @@
     }
 
     app.ajax = function(server, options) {
-        options.url = '//' + server.host + ':' + server.port + options.url;
+        if (server.host != null) {
+          if (server.port != null) {
+            options.url = '//' + server.host + ':' + server.port + options.url;
+          } else {
+            options.url = '//' + server.host + options.url;
+          }
+        }
         options.error = function(xhr, textStatus) { options.success(xhr.responseText, textStatus, xhr); };
         options.beforeSend = function(xhr) {
             if (server.user && server.pass) {


### PR DESCRIPTION
…ng null to be passed for server.host and server.port

Most deployments should be able to avoid setting host/port because the api is exposed at the current host (for internal deployments)