### PR TITLE
add VCL_log to Log Entry Tag

### DIFF
--- a/logs.html
+++ b/logs.html
@@ -129,6 +129,7 @@
                       <option value="VCL_call">VCL_call</option>
                       <option value="VCL_return">VCL_return</option>
                       <option value="VCL_trace">VCL_trace</option>
+                      <option value="VCL_log">VCL_log</option>
                       <option value="WorkThread">WorkThread</option>
                     </select>
 


### PR DESCRIPTION
missing tag `VCL_log` when using `std.log("this is my log");`
